### PR TITLE
mark-devkit: Bump gui-libs/eglexternalplatform-1.1-r1

### DIFF
--- a/gui-libs/eglexternalplatform/eglexternalplatform-1.1-r1.ebuild
+++ b/gui-libs/eglexternalplatform/eglexternalplatform-1.1-r1.ebuild
@@ -10,6 +10,12 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="*"
 
+src_prepare() {
+	default
+
+	use !prefix || sed -i "/^inc/s|=|=${EPREFIX}|" eglexternalplatform.pc || die
+}
+
 src_install() {
 	insinto /usr/$(get_libdir)/pkgconfig
 	doins eglexternalplatform.pc


### PR DESCRIPTION
Automatic bump of package gui-libs/eglexternalplatform-1.1-r1 for branch mark-iii by mark-bot