### PR TITLE
mark-devkit: Bump media-libs/vulkan-layers-1.3.290.0-r1

### DIFF
--- a/media-libs/vulkan-layers/vulkan-layers-1.3.290.0-r1.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-1.3.290.0-r1.ebuild
@@ -20,7 +20,6 @@ DEPEND="
 	=dev-util/glslang-1.3.290.0_p20240625*
 	=dev-util/spirv-tools-2024.2_p20240620*
 	=dev-util/vulkan-headers-1.3.290*
-	dev-util/vulkan-utility-libraries
 	${PYTHON_DEPS}
 	dev-cpp/robin-hood-hashing
 	wayland? ( dev-libs/wayland:= )
@@ -34,9 +33,20 @@ post_src_unpack() {
 	mv "${WORKDIR}"/KhronosGroup-Vulkan-ValidationLayers-* "${S}" || die
 }
 
+post_src_prepare() {
+	# FL-9238: dealing with an upstream change where the link was to the wrong dir. This probably won't be needed forever:
+	# https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/2c2b81c05189790acfea79873f1ea689827ad998#diff-ff032a8648100262964374becd9dd6fa56d9d1c02c6596a83128241ff668038bR307
+
+	sed -i \
+		-e '/target_link_libraries.*VkLayer_khronos_validation PRIVATE.*SPIRV-Tools-static/s/SPIRV-Tools-static/SPIRV-Tools/' \
+	"${S}"/layers/CMakeLists.txt || ewarn "The fix for FL-9238 can likely be removed from the vulkan-layers autogen now."
+	return 0
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
+		-DBUILD_LAYER_SUPPORT_FILES=ON
 		-DBUILD_WSI_WAYLAND_SUPPORT=$(usex wayland)
 		-DBUILD_WSI_XCB_SUPPORT=$(usex X)
 		-DBUILD_WSI_XLIB_SUPPORT=$(usex X)
@@ -44,6 +54,7 @@ src_configure() {
 		-DGLSLANG_INSTALL_DIR="${EPREFIX}/usr"
 		-DCMAKE_INSTALL_INCLUDEDIR="${EPREFIX}/usr/include/"
 		-DSPIRV_HEADERS_INSTALL_DIR="${EPREFIX}/usr"
+		-DVulkanRegistry_DIR="${EPREFIX}/usr/share/vulkan/registry"
 	)
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Automatic bump of package media-libs/vulkan-layers-1.3.290.0-r1 for branch mark-iii by mark-bot