### PR TITLE
mark-devkit: [mark-31] Bump media-libs/glu-9.0.3-r1

### DIFF
--- a/media-libs/glu/glu-9.0.3-r1.ebuild
+++ b/media-libs/glu/glu-9.0.3-r1.ebuild
@@ -19,7 +19,7 @@ DEPEND="${RDEPEND}
 "
 src_configure() {
 	local emesonargs=(
-	  -Dgl_provider=$(usex glvnd libglvnd gl)
+	  -Dgl_provider=$(usex libglvnd glvnd gl)
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
Automatic bump of package media-libs/glu-9.0.3-r1 for branch mark-31 by mark-bot